### PR TITLE
Remove Extension (DT) WP Admin menu declaration to avoid duplicate menus.

### DIFF
--- a/includes/admin/admin-menu-and-tabs.php
+++ b/includes/admin/admin-menu-and-tabs.php
@@ -138,7 +138,6 @@ class DT_Data_Reporting_Menu {
      * @since 0.1
      */
     public function register_menu() {
-        add_menu_page( __( 'Extensions (DT)', 'disciple_tools' ), __( 'Extensions (DT)', 'disciple_tools' ), 'manage_dt', 'dt_extensions', array( $this, 'extensions_menu' ), 'dashicons-admin-generic', 59 );
         add_submenu_page( 'dt_extensions', __( 'Data Reporting', 'DT_Data_Reporting' ), __( 'Data Reporting', 'DT_Data_Reporting' ), 'manage_dt', $this->token, array( $this, 'content' ) );
     }
 


### PR DESCRIPTION
The menu item is declared by the theme. We want to avoid this:
- Extensions (DT)
- Utilities (D.T)
- Reports (D.T)
- Extensions (D.T)